### PR TITLE
Replication of original PR #98: feat: add support for workspace/symbol request

### DIFF
--- a/src/multilspy/lsp_protocol_handler/lsp_constants.py
+++ b/src/multilspy/lsp_protocol_handler/lsp_constants.py
@@ -57,3 +57,6 @@ class LSPConstants:
 
     # key used to represent children in document symbols
     CHILDREN = "children"
+
+    # key used to represent the location in symbols
+    LOCATION = "location"

--- a/tests/multilspy/test_multilspy_rust.py
+++ b/tests/multilspy/test_multilspy_rust.py
@@ -72,6 +72,23 @@ async def test_multilspy_rust_carbonyl():
                 ],
             )
 
+            result = await lsp.request_workspace_symbol("parse_or_run")
+
+            assert isinstance(result, list)
+            assert len(result) == 1
+
+            assert result == [{
+                'name': 'parse_or_run',
+                'kind': 12,
+                'location': {
+                    'uri': PurePath(context.source_directory, "src/cli/program.rs").as_uri(),
+                    'range': {
+                        'start': {'line': 10, 'character': 4},
+                        'end': {'line': 24, 'character': 5}
+                    }
+                }
+            }]
+
 @pytest.mark.asyncio
 async def test_multilspy_rust_completions_mediaplayer() -> None:
     """

--- a/tests/multilspy/test_sync_multilspy_rust.py
+++ b/tests/multilspy/test_sync_multilspy_rust.py
@@ -65,3 +65,20 @@ def test_multilspy_rust_carbonyl() -> None:
                     },
                 ],
             )
+
+            result = lsp.request_workspace_symbol("parse_or_run")
+
+            assert isinstance(result, list)
+            assert len(result) == 1
+
+            assert result == [{
+                'name': 'parse_or_run',
+                'kind': 12,
+                'location': {
+                    'uri': PurePath(context.source_directory, "src/cli/program.rs").as_uri(),
+                    'range': {
+                        'start': {'line': 10, 'character': 4},
+                        'end': {'line': 24, 'character': 5}
+                    }
+                }
+            }]


### PR DESCRIPTION
# PR Summary

Add Workspace Symbol Request Support

## Overview

This PR adds support for the workspace/symbol LSP request, allowing clients to find symbols across the workspace. The implementation includes new constants, methods, and comprehensive test coverage.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Feature      | Add workspace/symbol request support   |
| Test         | Add test cases for workspace symbol functionality |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `multilspy/lsp_protocol_handler/lsp_constants.py` | Add LOCATION constant for symbol location |
| `multilspy/language_server.py` | Add request_workspace_symbol method to handle workspace symbol requests |
| `multilspy/test_multilspy_rust.py` | Add test case for workspace symbol functionality |
| `multilspy/test_sync_multilspy_rust.py` | Add test case for request_workspace_symbol functionality |

---

## Notes for Reviewers

* The implementation follows the same pattern as existing request methods in the language server
* Test cases verify the expected behavior for specific symbols like "parse_or_run"